### PR TITLE
Fix minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Be creative and demonstrate your UI skills!
 
 ## Dependencies
 
-To build and run the api you'll need a have [docker](https://www.docker.com/products/docker-desktop).
+To build and run the api you'll need to have [docker](https://www.docker.com/products/docker-desktop).
 
 ## Build API Docker
 


### PR DESCRIPTION
Replaces "need a" with "need to" in docker instructions.